### PR TITLE
adding counts to report links

### DIFF
--- a/code/Report.php
+++ b/code/Report.php
@@ -127,6 +127,7 @@ class SS_Report extends ViewableData {
 		return $this->dataClass;
 	}
 
+
 	public function getLink($action = null) {
 		return Controller::join_links(
 			'admin/reports/',
@@ -134,6 +135,21 @@ class SS_Report extends ViewableData {
 			'/', // trailing slash needed if $action is null!
 			"$action"
 		);
+	}
+
+
+	/**
+	 * counts the number of objects returned
+	 * @param Array $params - any parameters for the sourceRecords
+	 * @return Int
+	 */
+	public function getCount($params = array()){
+		$sourceRecords = $this->sourceRecords($params, null, null);
+		if(!$sourceRecords instanceOf SS_List){
+			user_error($this->class."::sourceRecords does not return an SS_List", E_USER_NOTICE);
+			return "-1";
+		}
+		return $sourceRecords->count();
 	}
 
 	/**

--- a/code/ReportAdmin.php
+++ b/code/ReportAdmin.php
@@ -165,9 +165,9 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider {
 				'title' => _t('ReportAdmin.ReportTitle', 'Title'),
 			));
 
-			$columns->setFieldFormatting(array(
-				'title' => '<a href=\"$Link\" class=\"cms-panel-link\">$value</a>'
-			));
+		        $columns->setFieldFormatting(array(
+		            'title' => '<a href=\"$Link\" class=\"cms-panel-link\">$value ($Count)</a>'
+		        ));			
 			$gridField->addExtraClass('all-reports-gridfield');
 			$fields->push($gridField);
 		}


### PR DESCRIPTION
This will add a count for each report which is immensely useful in working out what reports need attention without opening all of them..... in a next phase, it might also be an idea to add "needs attention" levels... where reports with a certain count (e.g. brokenLinks.Count > 0) will turn red in list or something like that.