### PR TITLE
Require-dev for PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
 		}
 	},
 	"require-dev": {
-		"phpunit/PHPUnit": "~3.7"
+		"phpunit/PHPUnit": "~4.8"
 	}
 }


### PR DESCRIPTION
If not set, it breaks the root composer.json generation in travis-support, since it falls back to PHPUnit 3.7.
See https://github.com/silverstripe-labs/silverstripe-travis-support/blob/master/src/ComposerGenerator.php

See https://github.com/silverstripe/silverstripe-cms/commit/d9e292ba281342cc7943ae25538daa1d173fa0c6
for same fix on cms module.