### PR TITLE
Decouple from CMS module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
 
 env:
   - DB=MYSQL CORE_RELEASE=3.2
@@ -20,8 +19,6 @@ matrix:
       env: DB=MYSQL CORE_RELEASE=3
     - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
-    - php: 7.0
 
 before_script:
   - composer self-update || true

--- a/code/SideReport.php
+++ b/code/SideReport.php
@@ -88,8 +88,9 @@ class SideReportView extends ViewableData {
 		}
 		
 		if(isset($info['link']) && $info['link']) {
-			$linkBase = singleton('CMSPageEditController')->Link('show');
-			$link = ($info['link'] === true) ? Controller::join_links($linkBase, $record->ID) : $info['link'];
+			$link = ($info['link'] === true && $record->hasMethod('CMSEditLink'))
+				? $record->CMSEditLink()
+				: $info['link'];
 			return $prefix . "<a $classClause href=\"$link\">$val</a>";
 		} else {
 			return $prefix . "<span $classClause>$val</span>";

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.3",
+		"php": ">=5.3.3,<7",
 		"silverstripe/framework": "~3.2"
 	},
 	"require-dev": {


### PR DESCRIPTION
This module actually has a dependency on CMS for the SideReport class (in needs `CMSPageEditController`) see: https://github.com/silverstripe-labs/silverstripe-reports/blob/3.2.3/code/SideReport.php#L91

Also removed tests on PHP 7 and updated composer to reflect that PHP 7 is not supported